### PR TITLE
description

### DIFF
--- a/TPWACTrialB/ViewControllerCreateActivity.swift
+++ b/TPWACTrialB/ViewControllerCreateActivity.swift
@@ -135,7 +135,7 @@ class ViewControllerCreateActivity: UIViewController{
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        headFaculty.text = currentUser.getEmail()
+        //headFaculty.text = currentUser.getEmail()
     }
     
         


### PR DESCRIPTION
cancelled auto fill faculty name in create activities
added comments on how to add description and read description from firebase
@byoon-sketch @yt-zero we need one more attribute (description) for each activity created, can you add the ui on create activity?